### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/bbcdaas_common/bbcdaas_common/pom.xml
+++ b/bbcdaas_common/bbcdaas_common/pom.xml
@@ -143,7 +143,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<!-- connection pool for db -->


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

You should also consider updating your SVN (or just removing it) repo which is inside this repo: bbcdaas_common/.svn/pristine/52/52bb0ef155dc768bfb46e2214b3919ac525b2967.svn-base has the same vulnerability, but I don't think I should edit that file.
